### PR TITLE
temporary workaround for wcda archiving

### DIFF
--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -341,11 +341,11 @@ if [[ ${type} = "gdas" ]]; then
     echo  "${dirname}${head}sfcf${fhr}.nc              " >>gdas.txt
     fh=$((fh+3))
   done
-  flist="001 002 004 005 007 008"
-  for fhr in ${flist}; do
-    echo  "${dirname}${head}sfluxgrbf${fhr}.grib2      " >>gdas.txt
-    echo  "${dirname}${head}sfluxgrbf${fhr}.grib2.idx  " >>gdas.txt
-  done
+#  flist="001 002 004 005 007 008"
+#  for fhr in ${flist}; do
+#    echo  "${dirname}${head}sfluxgrbf${fhr}.grib2      " >>gdas.txt
+#    echo  "${dirname}${head}sfluxgrbf${fhr}.grib2.idx  " >>gdas.txt
+#  done
   
 
 


### PR DESCRIPTION


**Description**

Removes sfluxgrb files with the forecast hours of 001 002 004 005 007 008 from the archiving since these apparently aren't produced in the WCDA setup. There should be a smarter way to do this using lists passed down from the relevant config files, and we shouldn't be the ones to figure it out

**Type of change**

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested?**

Tested for one attempt to successfully complete the task in one cycle of a low-res WCDA experiment

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
