### PR TITLE
adds all ocean da files to archiving

### DIFF
--- a/ush/hpssarch_gen.sh
+++ b/ush/hpssarch_gen.sh
@@ -415,6 +415,11 @@ if [[ ${type} = "gdas" ]]; then
     #...........................
     echo "${dirname}/${head}*             " >>gdasocean.txt
     echo "${dirname}/MOM_input            " >>gdasocean.txt
+    echo "${dirname}/gdas.t??z.ocngrid.nc " >>gdasocean.txt
+    echo "${dirname}/bump/*               " >>gdasocean.txt
+    echo "${dirname}/diags/*              " >>gdasocean.txt
+    echo "${dirname}/logs/*               " >>gdasocean.txt
+    echo "${dirname}/yaml/*               " >>gdasocean.txt
 
     echo "${dirname}/RESTART/*            " >>gdasocean_restart.txt
 


### PR DESCRIPTION
Adds all the ocean da files (along with all the files except for RESTART, which has their own archive file) to the ocean archive file.

Depending on how big these get in full resolution, the diag files might later go into their own archive file.

File changed: ush/hpssarch_gen.sh

Tested by rerunning gdasarch in existing experiment ocn-da-lores on Hera and then extracting the respective archive file from HPSS and diffing the results with the COMROT contents.