### PR TITLE
added ocnanalvrfy to S2S workflow

### DIFF
--- a/jobs/rocoto/ocnanalvrfy.sh
+++ b/jobs/rocoto/ocnanalvrfy.sh
@@ -14,6 +14,6 @@ export jobid="${job}.$$"
 
 ###############################################################
 # Execute the JJOB
-#"${HOMEgfs}/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY"
+"${HOMEgfs}/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY"
 status=$?
 exit "${status}"

--- a/jobs/rocoto/ocnanalvrfy.sh
+++ b/jobs/rocoto/ocnanalvrfy.sh
@@ -14,6 +14,6 @@ export jobid="${job}.$$"
 
 ###############################################################
 # Execute the JJOB
-"${HOMEgfs}/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY"
+#"${HOMEgfs}/jobs/JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY"
 status=$?
 exit "${status}"

--- a/parm/config/config.ocnanalvrfy
+++ b/parm/config/config.ocnanalvrfy
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+########## config.ocnanalvrfy ##########
+# Pre Ocn Analysis specific
+
+echo "BEGIN: config.ocnanalvrfy"
+
+# Get task specific resources
+. "${EXPDIR}/config.resources" ocnanalvrfy
+echo "END: config.ocnanalvrfy"

--- a/parm/config/config.resources
+++ b/parm/config/config.resources
@@ -19,6 +19,8 @@ if [ $# -ne 1 ]; then
     echo "wavegempak waveawipsbulls waveawipsgridded"
     echo "postsnd awips gempak"
     echo "wafs wafsgrib2 wafsblending wafsgrib20p25 wafsblending0p25 wafsgcip"
+    echo "ocnanalprep ocnanalbmat ocnanalrun ocnanalpost ocnanalvrfy" 
+
     exit 1
 
 fi
@@ -323,6 +325,15 @@ elif [[ "${step}" = "ocnanalpost" ]]; then
     export nth_ocnanalpost=1
     npe_node_ocnanalpost=$(echo "${npe_node_max} / ${nth_ocnanalpost}" | bc)
     export npe_node_ocnanalpost
+
+elif [[ "${step}" = "ocnanalvrfy" ]]; then
+
+    export wtime_ocnanalvrfy="00:10:00"
+    export npe_ocnanalvrfy=1
+    export nth_ocnanalvrfy=1
+    npe_node_ocnanalvrfy=$(echo "${npe_node_max} / ${nth_ocnanalvrfy}" | bc)
+    export npe_node_ocnanalvrfy
+    export memory_ocnanalvrfy="24GB"
 
 elif [ ${step} = "anal" ]; then
 

--- a/workflow/applications.py
+++ b/workflow/applications.py
@@ -182,7 +182,7 @@ class AppConfig:
             configs += ['anal', 'analdiag']
 
         if self.do_jediocnvar:
-            configs += ['ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalpost']
+            configs += ['ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalpost', 'ocnanalvrfy']
         if self.do_ocean:
             configs += ['ocnpost']
 
@@ -359,7 +359,7 @@ class AppConfig:
             gdas_gfs_common_tasks_before_fcst += ['anal']
 
         if self.do_jediocnvar:
-            gdas_gfs_common_tasks_before_fcst += ['ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalpost']
+            gdas_gfs_common_tasks_before_fcst += ['ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalpost', 'ocnanalvrfy']
 
         gdas_gfs_common_tasks_before_fcst += ['sfcanl', 'analcalc']
 

--- a/workflow/rocoto/workflow_tasks.py
+++ b/workflow/rocoto/workflow_tasks.py
@@ -13,7 +13,7 @@ class Tasks:
     VALID_TASKS = ['aerosol_init', 'coupled_ic', 'getic', 'init',
                    'prep', 'anal', 'sfcanl', 'analcalc', 'analdiag', 'gldas', 'arch',
                    'atmanalprep', 'atmanalrun', 'atmanalpost',
-                   'ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalpost',
+                   'ocnanalprep', 'ocnanalbmat', 'ocnanalrun', 'ocnanalpost', 'ocnanalvrfy',
                    'earc', 'ecen', 'echgres', 'ediag', 'efcs',
                    'eobs', 'eomg', 'epos', 'esfc', 'eupd',
                    'atmensanalprep', 'atmensanalrun', 'atmensanalpost',
@@ -556,6 +556,22 @@ class Tasks:
 
         resources = self.get_resource('ocnanalpost')
         task = create_wf_task('ocnanalpost',
+                              resources,
+                              cdump=self.cdump,
+                              envar=self.envars,
+                              dependency=dependencies)
+
+        return task
+
+    def ocnanalvrfy(self):
+
+        deps = []
+        dep_dict = {'type': 'task', 'name': f'{self.cdump}ocnanalpost'}
+        deps.append(rocoto.add_dependency(dep_dict))
+        dependencies = rocoto.create_dependency(dep_condition='and', dep=deps)
+
+        resources = self.get_resource('ocnanalvrfy')
+        task = create_wf_task('ocnanalvrfy',
                               resources,
                               cdump=self.cdump,
                               envar=self.envars,


### PR DESCRIPTION

Added ocnanalvrfy task to workflow setup, with required infrastructure.

Tested with a stub jobs/rocoto/ocnanalvrfy.sh (no call to jjob) for two cycles with low-res WCDA on Hera. Turning vrfy on is next.

File added:
parm/config/config.ocnanalvrfy

Files changed:
jobs/rocoto/ocnanalvrfy.sh
parm/config/config.resources
workflow/applications.py
workflow/rocoto/workflow_tasks.py
